### PR TITLE
Use packaging to handle versions like 1.10rc1 etc.

### DIFF
--- a/leak/main.py
+++ b/leak/main.py
@@ -3,7 +3,7 @@ import functools
 
 import requests
 
-from distutils.version import StrictVersion
+from packaging.version import parse as parse_version
 
 from termcolor import colored
 
@@ -101,7 +101,7 @@ def main(package_name=''):
     most_recent_date = EPOCH_BEGIN
 
     try:
-        versions = sorted(releases.keys(), reverse=True, key=StrictVersion)
+        versions = sorted(releases.keys(), reverse=True, key=parse_version)
     except ValueError as e:
         logger.debug('Trying to sort versions as strings')
         splitter = functools.partial(versions_split, type_applyer=str)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 
-install_requires = ['requests', 'termcolor']
+install_requires = ['requests', 'termcolor','packaging']
 tests_require = install_requires + ['pytest']
 
 


### PR DESCRIPTION
I noticed that running leak on packages like e.g. django would fail because of the extra text in some versions' strings.  I changed leak to use the 'packaging' utility which handles this very nicely.  This addresses issue #3 .