### PR TITLE
Use packaging library for versions parsing

### DIFF
--- a/leak/main.py
+++ b/leak/main.py
@@ -3,7 +3,7 @@ import functools
 
 import requests
 
-from distutils.version import StrictVersion
+from packaging.version import parse as parse_version
 
 from termcolor import colored
 
@@ -101,7 +101,7 @@ def main(package_name=''):
     most_recent_date = EPOCH_BEGIN
 
     try:
-        versions = sorted(releases.keys(), reverse=True, key=StrictVersion)
+        versions = sorted(releases.keys(), reverse=True, key=parse_version)
     except ValueError as e:
         logger.debug('Trying to sort versions as strings')
         splitter = functools.partial(versions_split, type_applyer=str)

--- a/leak/main.py
+++ b/leak/main.py
@@ -77,7 +77,8 @@ def parse_packages_from_html(html_content):
 
 
 def search_for_package(package_name):
-    url_template = 'https://pypi.python.org/pypi?:action=search&term={package_name}'
+    url_template = ('https://pypi.python.org/'
+                    'pypi?:action=search&term={package_name}')
     url = url_template.format(package_name=package_name)
     resp = requests.get(url)
     if resp.status_code != 200:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,9 @@ from setuptools.command.test import test as TestCommand
 
 install_requires = ['requests', 'termcolor', 'packaging']
 tests_require = install_requires + [
-    'pytest',
+    'pytest==3.1.2',
     'tox==2.7.0',
+    'mock==2.0.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,11 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 
-install_requires = ['requests', 'termcolor','packaging']
-tests_require = install_requires + ['pytest']
+install_requires = ['requests', 'termcolor', 'packaging']
+tests_require = install_requires + [
+    'pytest',
+    'tox==2.7.0',
+]
 
 
 def read(f):
@@ -26,17 +29,20 @@ class PyTest(TestCommand):
 args = dict(
     name='leak',
     version='1.0.3',  # todo (misha): add reading version from init file
-    description=('Show available releases for package'),
+    description='Show available releases for package',
     long_description=read('README.rst'),
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 
-install_requires = ['requests', 'termcolor']
+install_requires = ['requests', 'termcolor','packaging']
 tests_require = install_requires + ['pytest']
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,15 @@
+import mock
+
+from leak import main
 
 
-def test_test():
-    pass
+def test_wrong_package_name(capsys):
+
+    with mock.patch('leak.main.get_package_data',
+                    side_effect=ValueError) as get_package_data_mock:
+        main.main('wrong_package')
+        get_package_data_mock.assert_called_once_with('wrong_package')
+
+    out, err = capsys.readouterr()
+
+    assert 'No such package' in out

--- a/tests/test_version_parser.py
+++ b/tests/test_version_parser.py
@@ -1,0 +1,20 @@
+import pytest
+
+from leak.version_parser import versions_split
+
+
+def test_versions_split():
+    pass
+
+
+def test_wrong_versions_split():
+    # too many dots
+    assert versions_split('1.2.3.4') == [0, 0, 0]
+
+    # test missing numeric version
+    with pytest.raises(ValueError):
+        versions_split('not.numeric')
+
+    # test not string provided
+    with pytest.raises(AttributeError):
+        versions_split(12345)

--- a/tests/test_version_parser.py
+++ b/tests/test_version_parser.py
@@ -4,7 +4,15 @@ from leak.version_parser import versions_split
 
 
 def test_versions_split():
-    pass
+    assert versions_split('1.8.1') == [1, 8, 1]
+    assert versions_split('1.4') == [1, 4, 0]
+    assert versions_split('2') == [2, 0, 0]
+
+
+def test_versions_split_str_mapping():
+    assert versions_split('1.11rc1', type_applyer=str) == ['1', '11rc1', '0']
+    assert versions_split('1.10b1', type_applyer=str) == ['1', '10b1', '0']
+    assert versions_split('text', type_applyer=str) == ['text', '0', '0']
 
 
 def test_wrong_versions_split():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py26,py27,py33,py34,py35,py36
+skip_missing_interpreters=true
 
 [testenv]
 deps=pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,5 @@ envlist = py26,py27,py33,py34,py35,py36
 skip_missing_interpreters=true
 
 [testenv]
-deps=pytest
+deps=.[test]
 commands=pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26,py27,py33,py34,py35,py36
+
+[testenv]
+deps=pytest
+commands=pytest


### PR DESCRIPTION
### Changes
* Add some tests
* Add tox to check package working on different python versions
* Use `packaging` instead of built in distutils