### PR TITLE
Update url_template to point to the new PyPI

### DIFF
--- a/leak/main.py
+++ b/leak/main.py
@@ -62,7 +62,7 @@ def show_package_info(data):
 
 
 def get_package_data(package_name):
-    url_template = 'http://pypi.python.org/pypi/{package_name}/json'
+    url_template = 'https://pypi.org/pypi/{package_name}/json'
     url = url_template.format(package_name=package_name)
     resp = requests.get(url)
     if resp.status_code != 200:


### PR DESCRIPTION
PyPI has switched from the old legacy system at pypi.python.org to
Warehouse, with a new domain (pypi.org). This change fixes an erroneous
"No such package" error for any given package search.